### PR TITLE
#463: added ability to use deviceName instead of browserName

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -65,7 +65,7 @@ type DefaultManager struct {
 
 // Find - default implementation Manager interface
 func (m *DefaultManager) Find(caps session.Caps, requestId uint64) (Starter, bool) {
-	browserName := caps.Name
+	browserName := browser(caps)
 	version := caps.Version
 	log.Printf("[%d] [LOCATING_SERVICE] [%s] [%s]", requestId, browserName, version)
 	service, version, ok := m.Config.Find(browserName, version)
@@ -90,6 +90,14 @@ func (m *DefaultManager) Find(caps session.Caps, requestId uint64) (Starter, boo
 		return &Driver{ServiceBase: serviceBase, Environment: *m.Environment, Caps: caps}, true
 	}
 	return nil, false
+}
+
+func browser(caps session.Caps) string {
+	browserName := caps.Name
+	if browserName != "" {
+		return browserName
+	}
+	return caps.DeviceName
 }
 
 func wait(u string, t time.Duration) error {

--- a/service_test.go
+++ b/service_test.go
@@ -255,7 +255,7 @@ func createDockerStarter(t *testing.T, env *service.Environment, cfg *config.Con
 	AssertThat(t, err, Is{nil})
 	manager := service.DefaultManager{Environment: env, Client: cli, Config: cfg}
 	caps := session.Caps{
-		Name:                  "firefox",
+		DeviceName:                  "firefox",
 		Version:               "33.0",
 		ScreenResolution:      "1024x768",
 		VNC:                   true,

--- a/session/session.go
+++ b/session/session.go
@@ -10,6 +10,7 @@ import (
 // Caps - user capabilities
 type Caps struct {
 	Name                  string                 `json:"browserName"`
+	DeviceName            string                 `json:"deviceName"`
 	Version               string                 `json:"version"`
 	W3CVersion            string                 `json:"browserVersion"`
 	ScreenResolution      string                 `json:"screenResolution"`


### PR DESCRIPTION
Now you can use `deviceName` instead of `browserName` in capabilities.
Need for Android automation, where `browserName` is used by default to initiate browser on device