### PR TITLE
Added ability to publish all browser container's ports

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,7 @@ type Browser struct {
 	ShmSize int64             `json:"shmSize,omitempty"`
 	Labels  map[string]string `json:"labels,omitempty"`
 	Sysctl  map[string]string `json:"sysctl,omitempty"`
+	PublishAllPorts bool	  `json:"publishAllPorts,omitempty"`
 }
 
 // Versions configuration

--- a/config/config.go
+++ b/config/config.go
@@ -50,17 +50,17 @@ type State struct {
 
 // Browser configuration
 type Browser struct {
-	Image   interface{}       `json:"image"`
-	Port    string            `json:"port"`
-	Path    string            `json:"path"`
-	Tmpfs   map[string]string `json:"tmpfs,omitempty"`
-	Volumes []string          `json:"volumes,omitempty"`
-	Env     []string          `json:"env,omitempty"`
-	Hosts   []string          `json:"hosts,omitempty"`
-	ShmSize int64             `json:"shmSize,omitempty"`
-	Labels  map[string]string `json:"labels,omitempty"`
-	Sysctl  map[string]string `json:"sysctl,omitempty"`
-	PublishAllPorts bool	  `json:"publishAllPorts,omitempty"`
+	Image           interface{}       `json:"image"`
+	Port            string            `json:"port"`
+	Path            string            `json:"path"`
+	Tmpfs           map[string]string `json:"tmpfs,omitempty"`
+	Volumes         []string          `json:"volumes,omitempty"`
+	Env             []string          `json:"env,omitempty"`
+	Hosts           []string          `json:"hosts,omitempty"`
+	ShmSize         int64             `json:"shmSize,omitempty"`
+	Labels          map[string]string `json:"labels,omitempty"`
+	Sysctl          map[string]string `json:"sysctl,omitempty"`
+	PublishAllPorts bool              `json:"publishAllPorts,omitempty"`
 }
 
 // Versions configuration

--- a/service/docker.go
+++ b/service/docker.go
@@ -78,6 +78,9 @@ func (d *Docker) StartWithCancel() (*StartedService, error) {
 		},
 		ExtraHosts: getExtraHosts(d.Service, d.Caps),
 	}
+	if (d.Service.PublishAllPorts == true){
+		hostConfig.PublishAllPorts = true
+	}
 	if len(d.Caps.DNSServers) > 0 {
 		hostConfig.DNS = d.Caps.DNSServers
 	}

--- a/service/docker.go
+++ b/service/docker.go
@@ -78,9 +78,7 @@ func (d *Docker) StartWithCancel() (*StartedService, error) {
 		},
 		ExtraHosts: getExtraHosts(d.Service, d.Caps),
 	}
-	if (d.Service.PublishAllPorts == true){
-		hostConfig.PublishAllPorts = true
-	}
+	hostConfig.PublishAllPorts = d.Service.PublishAllPorts
 	if len(d.Caps.DNSServers) > 0 {
 		hostConfig.DNS = d.Caps.DNSServers
 	}


### PR DESCRIPTION
I want to add ability to publish all expose ports of container with browser. It may be usefull for using custom browser-images (with additional services with their specific ports).
This new option configure for particular browser image:
```
{
  "chrome": {
    "default": "70.0",
    "versions": {
      "70.0": {
        "image": "cusom/selenoid/vnc_chrome:70",
        "port": "4444",
        "publishAllPorts": true
      }
    }
  }
}
```