### PR TITLE
Update hash for github.com/docker/docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: go
 
 go:
-  - 1.11.1
+  - 1.11.5
 
 services:
   - docker

--- a/docs/contributing.adoc
+++ b/docs/contributing.adoc
@@ -2,7 +2,7 @@
 
 To build Selenoid:
 
-. Install https://golang.org/doc/install[Golang] 1.11 and above.
+. Install https://golang.org/doc/install[Golang] 1.11.4 and above.
 
 . Setup `$GOPATH` https://github.com/golang/go/wiki/GOPATH[properly]
 

--- a/go.sum
+++ b/go.sum
@@ -21,7 +21,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/distribution v2.7.0-rc.0.0.20181024170156-93e082742a00+incompatible h1:YOfVNTgst//UrD5ZhDfbY0+GTSWjXfXOYLYHhw0kMpo=
 github.com/docker/distribution v2.7.0-rc.0.0.20181024170156-93e082742a00+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v0.7.3-0.20181109141713-1e7c43dfae3f h1:DEwzvuWWkXXJ1O12FoL5Tw/hzFuxGXuyncEA/BaxBRQ=
+github.com/docker/docker v0.7.3-0.20181109141713-1e7c43dfae3f h1:eQmVOY2I0OnpVWKgtFMG3hPP+/tRZD7Ri60c0fdpV/s=
 github.com/docker/docker v0.7.3-0.20181109141713-1e7c43dfae3f/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.3.0 h1:3lOnM9cSzgGwx8VfK/NGOW5fLQ0GjIlCkaktF+n1M6o=
 github.com/docker/go-connections v0.3.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=


### PR DESCRIPTION
Due to the changes in go1.11.4 (https://github.com/golang/go/commit/b86522faa54413930d6e9164973166490babc5de) the logic for calculating a hash for go.sum has changed and currently (with golang >= 1.11.4) command `go get` fails with an error: 
```
go: verifying github.com/docker/docker@v0.7.3-0.20181109141713-1e7c43dfae3f: checksum mismatch
	downloaded: h1:eQmVOY2I0OnpVWKgtFMG3hPP+/tRZD7Ri60c0fdpV/s=
	go.sum:     h1:DEwzvuWWkXXJ1O12FoL5Tw/hzFuxGXuyncEA/BaxBRQ=
```
This PR updates a hashes for affected packages (there is only one, actually).  Also it update version of golang on travis + specifies proper go version in doc for contribution