### PR TITLE
Change /ping to produce regular RFC3339 date/time

### DIFF
--- a/main.go
+++ b/main.go
@@ -265,7 +265,7 @@ func ping(w http.ResponseWriter, _ *http.Request) {
 		LastReloadTime string `json:"lastReloadTime"`
 		NumRequests    uint64 `json:"numRequests"`
 		Version        string `json:"version"`
-	}{time.Since(startTime).String(), conf.LastReloadTime.String(), getSerial(), gitRevision})
+	}{time.Since(startTime).String(), conf.LastReloadTime.Format(time.RFC3339), getSerial(), gitRevision})
 }
 
 func video(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Value produced by time#String() method is, according to the documentation, intended for debug only and cannot be easily parsed by the consumers. The same applies to Ggr.