### PR TITLE
docs/docker-compose: Fix default bridge network name

### DIFF
--- a/docs/docker-compose.adoc
+++ b/docs/docker-compose.adoc
@@ -16,7 +16,7 @@ services:
       - "$PWD:/opt/selenoid/logs"
     environment:
       - OVERRIDE_VIDEO_OUTPUT_DIR=$PWD
-    command: ["-conf", "/etc/selenoid/browsers.json", "-video-output-dir", "/opt/selenoid/video", "-log-output-dir", "/opt/selenoid/logs", "-container-network", "selenoid"]        
+    command: ["-conf", "/etc/selenoid/browsers.json", "-video-output-dir", "/opt/selenoid/video", "-log-output-dir", "/opt/selenoid/logs"]
     ports:
       - "4444:4444"     
 ----


### PR DESCRIPTION
when the default bridge network is used the custom docker network name should not be provided