### PR TITLE
Update docs for webdriver.io file uploads

### DIFF
--- a/docs/file-upload.adoc
+++ b/docs/file-upload.adoc
@@ -35,8 +35,8 @@ input.send_keys("/path/to/file/on/machine/which/runs/tests")
 [source,javascript]
 ----
 var filePath = path.join('/path/to/file/on/machine/which/runs/tests');
-browser.uploadFile(filePath);
-browser.chooseFile("input[type='file']", filePath);
+var remoteFilePath = browser.uploadFile(filePath);
+$("input[type='file']").setValue(remoteFilePath);
 ----
 
 Read the following note if you are using Selenoid **without Docker**.


### PR DESCRIPTION
WebdriverIO V5 changed how you need to do file uploads slightly so the example in the documentation here is now out of date.

See https://webdriver.io/docs/api/browser/uploadFile.html for their new format (represented in this change, and working in my test suite).