### PR TITLE
Make working example Docker command

### DIFF
--- a/docs/video.adoc
+++ b/docs/video.adoc
@@ -25,7 +25,7 @@ $ docker pull selenoid/video-recorder:latest-release
 +
 .Example Docker Command
 ----
-$ docker run -d
+$ docker run -d                                 \
 --name selenoid                                 \
 -p 4444:4444                                    \
 -v /var/run/docker.sock:/var/run/docker.sock    \


### PR DESCRIPTION
If the current command is copied and pasted, it doesn't work as it
needs a `\` at the end of the line. It is required as it allows to make
line continuation to collect the full command.