### PR TITLE
Handle http errors before changing queue stats (fixes #998)

### DIFF
--- a/main.go
+++ b/main.go
@@ -242,7 +242,7 @@ var seleniumPaths = struct {
 
 func selenium() http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc(seleniumPaths.CreateSession, queue.Try(queue.Check(queue.Protect(post(create)))))
+	mux.HandleFunc(seleniumPaths.CreateSession, post(queue.Try(queue.Check(queue.Protect(create)))))
 	mux.HandleFunc(seleniumPaths.ProxySession, proxy)
 	mux.HandleFunc(paths.Status, status)
 	mux.HandleFunc(paths.Welcome, welcome)


### PR DESCRIPTION
Will it fix this little bug? Looks like an easy solution, but I'm not sure if it's safe