### PR TITLE
Propagate Content-Type header if client sends it

### DIFF
--- a/selenoid.go
+++ b/selenoid.go
@@ -206,6 +206,10 @@ func create(w http.ResponseWriter, r *http.Request) {
 		r.URL.Host, r.URL.Path = u.Host, path.Join(u.Path, r.URL.Path)
 		newBody := removeSelenoidOptions(body)
 		req, _ := http.NewRequest(http.MethodPost, r.URL.String(), bytes.NewReader(newBody))
+		contentType := r.Header.Get("Content-Type")
+		if len(contentType) > 0 {
+			req.Header.Set("Content-Type", contentType)
+		}
 		ctx, done := context.WithTimeout(r.Context(), newSessionAttemptTimeout)
 		defer done()
 		log.Printf("[%d] [SESSION_ATTEMPTED] [%s] [%d]", requestId, u.String(), i)


### PR DESCRIPTION
Some webdrivers check Content-Type header (specifically on create session). Selenium client sends it, we just need to propagate it to the target container.