### PR TITLE
Move from io/ioutil to io and os packages

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,8 +3,8 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -85,7 +85,7 @@ func NewConfig() *Config {
 }
 
 func loadJSON(filename string, v interface{}) error {
-	buf, err := ioutil.ReadFile(filename)
+	buf, err := os.ReadFile(filename)
 	if err != nil {
 		return fmt.Errorf("read error: %v", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -1,17 +1,16 @@
 package config
 
 import (
-	"log"
-
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/aerokube/selenoid/session"
 	"github.com/docker/docker/api/types/container"
-	"time"
 )
 
 // Session - session id and vnc flag

--- a/config_test.go
+++ b/config_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -15,7 +14,7 @@ import (
 const testLogConf = "config/container-logs.json"
 
 func configfile(s string) string {
-	tmp, err := ioutil.TempFile("", "config")
+	tmp, err := os.CreateTemp("", "config")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,28 +3,31 @@ module github.com/aerokube/selenoid
 go 1.17
 
 require (
-	github.com/Microsoft/go-winio v0.4.12 // indirect
 	github.com/aandryashin/matchers v0.0.0-20161126170413-435295ea180e
 	github.com/aerokube/ggr v0.0.0-20181215175518-4a2e23fa1769
 	github.com/aerokube/util v0.0.0-20190701120823-161c21b50f69
 	github.com/aws/aws-sdk-go v1.20.12
-	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v0.7.3-0.20190629173937-e105a74c5419
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0
-	github.com/gogo/protobuf v1.2.1 // indirect
-	github.com/golang/protobuf v1.2.0 // indirect
 	github.com/gorilla/websocket v1.4.2
 	github.com/imdario/mergo v0.3.6
-	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
-	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
 	github.com/mafredri/cdp v0.21.0
-	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
-	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/pborman/uuid v0.0.0-20170612153648-e790cca94e6c
 	github.com/pkg/errors v0.8.1
-	github.com/sirupsen/logrus v1.4.2 // indirect
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a
+)
+
+require (
+	github.com/Microsoft/go-winio v0.4.12 // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/gogo/protobuf v1.2.1 // indirect
+	github.com/golang/protobuf v1.2.0 // indirect
+	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
+	github.com/opencontainers/image-spec v1.0.1 // indirect
+	github.com/sirupsen/logrus v1.4.2 // indirect
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
 	google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 // indirect
 	google.golang.org/grpc v1.21.1 // indirect

--- a/main.go
+++ b/main.go
@@ -4,27 +4,22 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"github.com/aerokube/selenoid/jsonerror"
-	"github.com/pkg/errors"
+	"fmt"
 	"log"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
-	"golang.org/x/net/websocket"
-
-	"fmt"
-
-	"path/filepath"
-
 	ggr "github.com/aerokube/ggr/config"
 	"github.com/aerokube/selenoid/config"
+	"github.com/aerokube/selenoid/jsonerror"
 	"github.com/aerokube/selenoid/protect"
 	"github.com/aerokube/selenoid/service"
 	"github.com/aerokube/selenoid/session"
@@ -32,6 +27,8 @@ import (
 	"github.com/aerokube/util"
 	"github.com/aerokube/util/docker"
 	"github.com/docker/docker/client"
+	"github.com/pkg/errors"
+	"golang.org/x/net/websocket"
 )
 
 var (

--- a/metadata.go
+++ b/metadata.go
@@ -5,8 +5,8 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -39,7 +39,7 @@ func (mp *MetadataProcessor) OnSessionStopped(stoppedSession event.StoppedSessio
 			return
 		}
 		filename := filepath.Join(logOutputDir, stoppedSession.SessionId+metadataFileExtension)
-		err = ioutil.WriteFile(filename, data, 0644)
+		err = os.WriteFile(filename, data, 0644)
 		if err != nil {
 			log.Printf("[%d] [METADATA] [%s] [Failed to save to %s: %v]", stoppedSession.RequestId, stoppedSession.SessionId, filename, err)
 			return

--- a/metadata.go
+++ b/metadata.go
@@ -1,15 +1,17 @@
+//go:build metadata
 // +build metadata
 
 package main
 
 import (
 	"encoding/json"
-	"github.com/aerokube/selenoid/event"
-	"github.com/aerokube/selenoid/session"
 	"io/ioutil"
 	"log"
 	"path/filepath"
 	"time"
+
+	"github.com/aerokube/selenoid/event"
+	"github.com/aerokube/selenoid/session"
 )
 
 const metadataFileExtension = ".json"

--- a/protect/queue.go
+++ b/protect/queue.go
@@ -2,12 +2,12 @@ package protect
 
 import (
 	"errors"
-	"github.com/aerokube/selenoid/jsonerror"
 	"log"
 	"math"
 	"net/http"
 	"time"
 
+	"github.com/aerokube/selenoid/jsonerror"
 	"github.com/aerokube/util"
 )
 

--- a/s3_test.go
+++ b/s3_test.go
@@ -1,13 +1,10 @@
+//go:build s3
 // +build s3
 
 package main
 
 import (
 	"context"
-	. "github.com/aandryashin/matchers"
-	"github.com/aerokube/selenoid/event"
-	"github.com/aerokube/selenoid/session"
-	"github.com/aerokube/selenoid/upload"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -15,6 +12,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	. "github.com/aandryashin/matchers"
+	"github.com/aerokube/selenoid/event"
+	"github.com/aerokube/selenoid/session"
+	"github.com/aerokube/selenoid/upload"
 )
 
 var (

--- a/s3_test.go
+++ b/s3_test.go
@@ -5,10 +5,10 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -64,7 +64,7 @@ func TestS3Uploader(t *testing.T) {
 		ReducedRedundancy: true,
 	}
 	uploader.Init()
-	f, _ := ioutil.TempFile("", "some-file")
+	f, _ := os.CreateTemp("", "some-file")
 	input := event.CreatedFile{
 		Event: event.Event{
 			RequestId: 4342,

--- a/selenoid.go
+++ b/selenoid.go
@@ -9,10 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/aerokube/selenoid/event"
-	"github.com/aerokube/selenoid/jsonerror"
-	"github.com/aerokube/selenoid/service"
-	"github.com/imdario/mergo"
 	"io"
 	"io/ioutil"
 	"log"
@@ -28,10 +24,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aerokube/selenoid/event"
+	"github.com/aerokube/selenoid/jsonerror"
+	"github.com/aerokube/selenoid/service"
 	"github.com/aerokube/selenoid/session"
 	"github.com/aerokube/util"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/imdario/mergo"
 	"golang.org/x/net/websocket"
 )
 

--- a/selenoid.go
+++ b/selenoid.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -112,7 +111,7 @@ func create(w http.ResponseWriter, r *http.Request) {
 	sessionStartTime := time.Now()
 	requestId := serial()
 	user, remote := util.RequestInfo(r)
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	r.Body.Close()
 	if err != nil {
 		log.Printf("[%d] [ERROR_READING_REQUEST] [%v]", requestId, err)
@@ -680,7 +679,7 @@ func logs(w http.ResponseWriter, r *http.Request) {
 }
 
 func listFilesAsJson(requestId uint64, w http.ResponseWriter, dir string, errStatus string) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		log.Printf("[%d] [%s] [%s]", requestId, errStatus, fmt.Sprintf("Failed to list directory %s: %v", logOutputDir, err))
 		w.WriteHeader(http.StatusInternalServerError)

--- a/selenoid_test.go
+++ b/selenoid_test.go
@@ -3,26 +3,24 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
-	"github.com/mafredri/cdp"
-	"github.com/mafredri/cdp/rpcc"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/aerokube/selenoid/config"
-
-	"encoding/json"
-	"path/filepath"
-
 	. "github.com/aandryashin/matchers"
 	. "github.com/aandryashin/matchers/httpresp"
 	ggr "github.com/aerokube/ggr/config"
+	"github.com/aerokube/selenoid/config"
+	"github.com/mafredri/cdp"
+	"github.com/mafredri/cdp/rpcc"
 )
 
 var _ = func() bool {

--- a/selenoid_test.go
+++ b/selenoid_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -34,8 +34,8 @@ var (
 
 func init() {
 	enableFileUpload = true
-	videoOutputDir, _ = ioutil.TempDir("", "selenoid-test")
-	logOutputDir, _ = ioutil.TempDir("", "selenoid-test")
+	videoOutputDir, _ = os.MkdirTemp("", "selenoid-test")
+	logOutputDir, _ = os.MkdirTemp("", "selenoid-test")
 	saveAllLogs = true
 	gitRevision = "test-revision"
 	ggrHost = &ggr.Host{
@@ -652,7 +652,7 @@ func TestFileUpload(t *testing.T) {
 	f, err := os.Open(jsonResponse["value"])
 	AssertThat(t, err, Is{nil})
 
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 	AssertThat(t, err, Is{nil})
 
 	AssertThat(t, string(content), EqualTo{"Hello World!"})
@@ -720,7 +720,7 @@ func TestPing(t *testing.T) {
 	AssertThat(t, rsp.Body, Is{Not{nil}})
 
 	var data map[string]interface{}
-	bt, readErr := ioutil.ReadAll(rsp.Body)
+	bt, readErr := io.ReadAll(rsp.Body)
 	AssertThat(t, readErr, Is{nil})
 	jsonErr := json.Unmarshal(bt, &data)
 	AssertThat(t, jsonErr, Is{nil})
@@ -743,7 +743,7 @@ func TestStatus(t *testing.T) {
 	AssertThat(t, rsp.Body, Is{Not{nil}})
 
 	var data map[string]interface{}
-	bt, readErr := ioutil.ReadAll(rsp.Body)
+	bt, readErr := io.ReadAll(rsp.Body)
 	AssertThat(t, readErr, Is{nil})
 	jsonErr := json.Unmarshal(bt, &data)
 	AssertThat(t, jsonErr, Is{nil})
@@ -760,7 +760,7 @@ func TestStatus(t *testing.T) {
 func TestServeAndDeleteVideoFile(t *testing.T) {
 	fileName := "testfile"
 	filePath := filepath.Join(videoOutputDir, fileName)
-	ioutil.WriteFile(filePath, []byte("test-data"), 0644)
+	os.WriteFile(filePath, []byte("test-data"), 0644)
 
 	rsp, err := http.Get(With(srv.URL).Path("/video/testfile"))
 	AssertThat(t, err, Is{nil})
@@ -787,7 +787,7 @@ func TestServeAndDeleteVideoFile(t *testing.T) {
 func TestServeAndDeleteLogFile(t *testing.T) {
 	fileName := "logfile.log"
 	filePath := filepath.Join(logOutputDir, fileName)
-	ioutil.WriteFile(filePath, []byte("test-data"), 0644)
+	os.WriteFile(filePath, []byte("test-data"), 0644)
 
 	rsp, err := http.Get(With(srv.URL).Path("/logs/logfile.log"))
 	AssertThat(t, err, Is{nil})
@@ -822,7 +822,7 @@ func TestFileDownload(t *testing.T) {
 	rsp, err := http.Get(With(srv.URL).Path(fmt.Sprintf("/download/%s/testfile", sess["sessionId"])))
 	AssertThat(t, err, Is{nil})
 	AssertThat(t, rsp, Code{http.StatusOK})
-	data, err := ioutil.ReadAll(rsp.Body)
+	data, err := io.ReadAll(rsp.Body)
 	AssertThat(t, err, Is{nil})
 	AssertThat(t, string(data), EqualTo{"test-data"})
 
@@ -848,7 +848,7 @@ func TestClipboard(t *testing.T) {
 	rsp, err := http.Get(With(srv.URL).Path(fmt.Sprintf("/clipboard/%s", sess["sessionId"])))
 	AssertThat(t, err, Is{nil})
 	AssertThat(t, rsp, Code{http.StatusOK})
-	data, err := ioutil.ReadAll(rsp.Body)
+	data, err := io.ReadAll(rsp.Body)
 	AssertThat(t, err, Is{nil})
 	AssertThat(t, string(data), EqualTo{"test-clipboard-value"})
 

--- a/service/docker.go
+++ b/service/docker.go
@@ -3,11 +3,13 @@ package service
 import (
 	"context"
 	"fmt"
-	"github.com/docker/go-units"
 	"log"
 	"net"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aerokube/selenoid/config"
@@ -20,9 +22,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
-	"os"
-	"path/filepath"
-	"strings"
+	"github.com/docker/go-units"
 )
 
 const (

--- a/service/driver.go
+++ b/service/driver.go
@@ -1,18 +1,18 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net"
 	"net/url"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"time"
 
-	"errors"
 	"github.com/aerokube/selenoid/session"
 	"github.com/aerokube/util"
-	"os"
-	"path/filepath"
 )
 
 // Driver - driver processes manager
@@ -77,11 +77,11 @@ func (d *Driver) StartWithCancel() (*StartedService, error) {
 	}
 	log.Printf("[%d] [PROCESS_STARTED] [%d] [%.2fs]", requestId, cmd.Process.Pid, util.SecondsSince(s))
 	log.Printf("[%d] [PROXY_TO] [%s]", requestId, u.String())
-        hp := session.HostPort{}
-        if d.Caps.VNC {
-                hp.VNC = "127.0.0.1:5900"
-        }
-        return &StartedService{Url: u, HostPort: hp, Cancel: func() { d.stopProcess(cmd) }}, nil
+	hp := session.HostPort{}
+	if d.Caps.VNC {
+		hp.VNC = "127.0.0.1:5900"
+	}
+	return &StartedService{Url: u, HostPort: hp, Cancel: func() { d.stopProcess(cmd) }}, nil
 }
 
 func (d *Driver) stopProcess(cmd *exec.Cmd) {

--- a/service/driver_unix.go
+++ b/service/driver_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package service
@@ -8,7 +9,7 @@ import (
 )
 
 func stopProc(cmd *exec.Cmd) error {
-		exitCode := cmd.Process.Signal(syscall.SIGINT)
-		cmd.Wait()
-		return exitCode
+	exitCode := cmd.Process.Signal(syscall.SIGINT)
+	cmd.Wait()
+	return exitCode
 }

--- a/service/driver_windows.go
+++ b/service/driver_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package service

--- a/service_test.go
+++ b/service_test.go
@@ -3,14 +3,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	. "github.com/aandryashin/matchers"
-	"github.com/aerokube/selenoid/config"
-	"github.com/aerokube/selenoid/service"
-	"github.com/aerokube/selenoid/session"
-	"github.com/aerokube/util"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/client"
-	"golang.org/x/net/websocket"
 	"io"
 	"io/ioutil"
 	"net"
@@ -21,6 +13,15 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	. "github.com/aandryashin/matchers"
+	"github.com/aerokube/selenoid/config"
+	"github.com/aerokube/selenoid/service"
+	"github.com/aerokube/selenoid/session"
+	"github.com/aerokube/util"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"golang.org/x/net/websocket"
 )
 
 var (

--- a/service_test.go
+++ b/service_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -223,7 +222,7 @@ func testConfig(env *service.Environment) *config.Config {
 }
 
 func testEnvironment() *service.Environment {
-	logOutputDir, _ = ioutil.TempDir("", "selenoid-test")
+	logOutputDir, _ = os.MkdirTemp("", "selenoid-test")
 	return &service.Environment{
 		CPU:                 int64(0),
 		Memory:              int64(0),

--- a/session/session.go
+++ b/session/session.go
@@ -1,10 +1,11 @@
 package session
 
 import (
-	"github.com/imdario/mergo"
 	"net/url"
 	"sync"
 	"time"
+
+	"github.com/imdario/mergo"
 )
 
 // Caps - user capabilities

--- a/upload/s3.go
+++ b/upload/s3.go
@@ -1,3 +1,4 @@
+//go:build s3
 // +build s3
 
 package upload
@@ -5,18 +6,19 @@ package upload
 import (
 	"flag"
 	"fmt"
-	"github.com/aerokube/selenoid/event"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	awssession "github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-	"github.com/pkg/errors"
 	"log"
 	"mime"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/aerokube/selenoid/event"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	awssession "github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/pkg/errors"
 )
 
 func init() {

--- a/upload/uploader.go
+++ b/upload/uploader.go
@@ -1,10 +1,11 @@
 package upload
 
 import (
-	"github.com/aerokube/selenoid/event"
-	"github.com/aerokube/util"
 	"log"
 	"time"
+
+	"github.com/aerokube/selenoid/event"
+	"github.com/aerokube/util"
 )
 
 var (

--- a/utils_test.go
+++ b/utils_test.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/aerokube/selenoid/protect"
-	"github.com/gorilla/websocket"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -14,14 +12,14 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-
+	"testing"
 	"time"
 
-	"testing"
-
 	. "github.com/aandryashin/matchers"
+	"github.com/aerokube/selenoid/protect"
 	"github.com/aerokube/selenoid/service"
 	"github.com/aerokube/selenoid/session"
+	"github.com/gorilla/websocket"
 	"github.com/pborman/uuid"
 )
 


### PR DESCRIPTION
This PR introduces three small changes:

1. Formats the code by running `go fmt ./...`. 

2. Runs `go mod tidy -go=1.17` to add another `require` directive to `go.mod` file to enable [module graph pruning](https://golang.org/ref/mod#graph-pruning) and [lazy module loading](https://golang.org/ref/mod#lazy-loading).

3. The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.