### PR TITLE
Use the appium:deviceName capability to find the specific browser

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -16,6 +16,7 @@ type Caps struct {
 	W3CVersion            string            `json:"browserVersion,omitempty"`
 	Platform              string            `json:"platform,omitempty"`
 	W3CPlatform           string            `json:"platformName,omitempty"`
+	W3CDeviceName         string            `json:"appium:deviceName,omitempty"`
 	ScreenResolution      string            `json:"screenResolution,omitempty"`
 	Skin                  string            `json:"skin,omitempty"`
 	VNC                   bool              `json:"enableVNC,omitempty"`
@@ -47,6 +48,9 @@ func (c *Caps) ProcessExtensionCapabilities() {
 	if c.W3CPlatform != "" {
 		c.Platform = c.W3CPlatform
 	}
+	if c.W3CDeviceName != "" {
+		c.DeviceName = c.W3CDeviceName
+	}
 
 	if c.ExtensionCapabilities != nil {
 		mergo.Merge(c, *c.ExtensionCapabilities, mergo.WithOverride) //We probably need to handle returned error
@@ -58,7 +62,10 @@ func (c *Caps) BrowserName() string {
 	if browserName != "" {
 		return browserName
 	}
-	return c.DeviceName
+	if c.DeviceName != "" {
+		return c.DeviceName
+	}
+	return c.W3CDeviceName
 }
 
 // Container - container information

--- a/utils_test.go
+++ b/utils_test.go
@@ -188,6 +188,7 @@ func TestProcessExtensionCapabilities(t *testing.T) {
 	capsJson := `{
 		"version": "57.0",
 		"browserName": "firefox",
+		"appium:deviceName": "android",
 		"selenoid:options": {
 			"name": "ExampleTestName",
 			"enableVNC": true,
@@ -206,6 +207,7 @@ func TestProcessExtensionCapabilities(t *testing.T) {
 	caps.ProcessExtensionCapabilities()
 	AssertThat(t, caps.Name, EqualTo{"firefox"})
 	AssertThat(t, caps.Version, EqualTo{"57.0"})
+	AssertThat(t, caps.DeviceName, EqualTo{"android"})
 	AssertThat(t, caps.TestName, EqualTo{"ExampleTestName"})
 	AssertThat(t, caps.VNC, EqualTo{true})
 	AssertThat(t, caps.VideoFrameRate, EqualTo{uint16(24)})
@@ -249,4 +251,31 @@ func TestSumUsedTotalGreaterThanPending(t *testing.T) {
 	AssertThat(t, err, Not{nil})
 	AssertThat(t, queue.Pending(), EqualTo{0})
 	AssertThat(t, queue.Used(), EqualTo{2})
+}
+
+func TestBrowserName(t *testing.T) {
+	var caps session.Caps
+
+	var capsJson = `{
+		"appium:deviceName": "iPhone 7"
+	}`
+	err := json.Unmarshal([]byte(capsJson), &caps)
+	AssertThat(t, err, Is{nil})
+	AssertThat(t, caps.BrowserName(), EqualTo{"iPhone 7"})
+
+	capsJson = `{
+		"deviceName": "android 11"
+	}`
+	err = json.Unmarshal([]byte(capsJson), &caps)
+	AssertThat(t, err, Is{nil})
+	AssertThat(t, caps.BrowserName(), EqualTo{"android 11"})
+
+	capsJson = `{
+		"deviceName": "android 11",
+		"appium:deviceName": "iPhone 7",
+		"browserName": "firefox"
+	}`
+	err = json.Unmarshal([]byte(capsJson), &caps)
+	AssertThat(t, err, Is{nil})
+	AssertThat(t, caps.BrowserName(), EqualTo{"firefox"})
 }


### PR DESCRIPTION
Use the `appium:deviceName` capability to find the specific browser as well. New Appium clients do not send the non-W3C `deviceName` capability.