### PR TITLE
fix docker-network compatibility for arm64 Selenoid

### DIFF
--- a/docs/cli-flags.adoc
+++ b/docs/cli-flags.adoc
@@ -11,6 +11,8 @@ The following flags are supported by `selenoid` command:
     Network to be used for containers (default "default")
 -cpu value
     Containers cpu limit as float e.g. 0.2 or 1.0
+-in-docker
+    Indicate that selenoid process runs inside a container. Necessary to using with docker-compose and arm64 container
 -disable-docker
     Disable docker support
 -disable-privileged

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ import (
 var (
 	hostname                 string
 	disableDocker            bool
+	inDocker                 bool
 	disableQueue             bool
 	enableFileUpload         bool
 	listen                   string
@@ -72,6 +73,7 @@ func init() {
 	var mem service.MemLimit
 	var cpu service.CpuLimit
 	flag.BoolVar(&disableDocker, "disable-docker", false, "Disable docker support")
+	flag.BoolVar(&inDocker, "in-docker", false, "Indicate that selenoid process runs inside a container")
 	flag.BoolVar(&disableQueue, "disable-queue", false, "Disable wait queue")
 	flag.BoolVar(&enableFileUpload, "enable-file-upload", false, "File upload support")
 	flag.StringVar(&listen, "listen", ":4444", "Network address to accept connections")
@@ -122,9 +124,8 @@ func init() {
 			log.Printf("[-] [INIT] [%s: %v]", os.Args[0], err)
 		}
 	})
-	inDocker := false
 	_, err = os.Stat("/.dockerenv")
-	if err == nil || containerNetwork != service.DefaultContainerNetwork {
+	if err == nil {
 		inDocker = true
 	}
 

--- a/main.go
+++ b/main.go
@@ -124,7 +124,7 @@ func init() {
 	})
 	inDocker := false
 	_, err = os.Stat("/.dockerenv")
-	if err == nil {
+	if err == nil || containerNetwork != service.DefaultContainerNetwork {
 		inDocker = true
 	}
 


### PR DESCRIPTION
arm64 Selenoid image (1.10.10) defines `InDocker` var incorrectly because file .dockerenv is missing in arm64 container:
![telegram-cloud-photo-size-2-5217748643568797032-y](https://user-images.githubusercontent.com/25635227/224548050-7ae74b90-49e1-4f30-bacb-fed4f45394f2.jpg)

This issue causes the custom docker-network to become unusable. 