### PR TITLE
Добавить возможность уведомить ggr после старта

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,8 +97,8 @@ func init() {
 	flag.StringVar(&logOutputDir, "log-output-dir", "", "Directory to save session log to")
 	flag.BoolVar(&saveAllLogs, "save-all-logs", false, "Whether to save all logs without considering capabilities")
 	flag.DurationVar(&gracefulPeriod, "graceful-period", 300*time.Second, "graceful shutdown period in time.Duration format, e.g. 300s or 500ms")
-	flag.StringVar(&notifyHost, "notify-host", "", "Specify ggr host to notify")
-	flag.StringVar(&notifyHostUser, "notify-host-user", "", "Specify ggr host user to update quota")
+	flag.StringVar(&notifyHost, "notify-ggr", "", "Specify ggr host to notify")
+	flag.StringVar(&notifyHostUser, "notify-ggr-user", "", "Specify ggr host user to update quota")
 	flag.Parse()
 
 	if version {

--- a/main.go
+++ b/main.go
@@ -207,7 +207,8 @@ func init() {
 	}
 	manager = &service.DefaultManager{Environment: &environment, Client: cli, Config: conf}
 	if notifyHost != "" {
-		notifyGgr(notifyHost, notifyHostUser)
+		serverURL := fmt.Sprintf("http://%s/notify", notifyHost)
+		notifyGgr(serverURL, notifyHostUser)
 	}
 }
 


### PR DESCRIPTION
Хотелось бы добавить возможность уведомлять ggr после старта selenoid и во время работы.
через два параметра 
`--notify-ggr "ggr-adress-here" --notify-ggr-user "test"`

пример применения, представим что на AWS добавлено правило когда стали доступны spot instance по указаной цене, то стартует новый instance с уже подготовленным обзаром, где docker + selenoid
после старта selenoid уведомляет ggr что готов работать, а ggr в свою очередь обновляет для пользователя quota xml фаил и теперь с новым сервером можно работать.

Хотел узнать верно ли я написал код? сделайте пожалуйста код ревью.

ggr часть доступна тут https://github.com/aerokube/ggr/pull/381
@vania-pooh @aandryashin code review please