### PR TITLE
fix: correctly parse sessionId for chrome less 75

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v3
         with:
-          go-version: ~1.20.4
+          go-version: ~1.20.6
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v3
         with:
-          go-version: ~1.20.4
+          go-version: ~1.20.6
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v3
         with:
-          go-version: ~1.20.4
+          go-version: ~1.20.6
 
       - uses: actions/cache@v3
         with:

--- a/selenoid.go
+++ b/selenoid.go
@@ -413,12 +413,19 @@ func processBody(input []byte, host string) ([]byte, string, error) {
 	if err != nil {
 		return nil, sessionId, fmt.Errorf("parse body response: %v", err)
 	}
-	if raw, ok := body["value"]; ok {
-		if v, ok := raw.(map[string]interface{}); ok {
-			if raw, ok := v["capabilities"]; ok {
-				if c, ok := raw.(map[string]interface{}); ok {
-					sessionId = v["sessionId"].(string)
-					c["se:cdp"] = fmt.Sprintf("ws://%s/devtools/%s/", host, sessionId)
+	// handle jsonwp response from older browsers (chrome < 75)
+	if rawId, ok := body["sessionId"]; ok {
+		if si, ok := rawId.(string); ok {
+			sessionId = si
+		}
+	} else {
+		if raw, ok := body["value"]; ok {
+			if v, ok := raw.(map[string]interface{}); ok {
+				if raw, ok := v["capabilities"]; ok {
+					if c, ok := raw.(map[string]interface{}); ok {
+						sessionId = v["sessionId"].(string)
+						c["se:cdp"] = fmt.Sprintf("ws://%s/devtools/%s/", host, sessionId)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
In the process of implementing #1354, I broke work with the chrome browser version below 75. Response body from chrome@67 looks like this:
```
{
    sessionId: "session_id",
    status: 0,
    value: {
        browserName: "chrome",
        // ... (without "capabilities" field)
    }
}
```

In chrome 75 and older looks like this:
```
{
    value: {
        capabilities: {
            browserName: "chrome",
            // ...
        },
        sessionId: "session_id"
    }
}
```

It means that `sessionId` can be located in different places depending on browser version.