### PR TITLE
Capture Stdin so that we can work with WinAppDriver

### DIFF
--- a/service/driver.go
+++ b/service/driver.go
@@ -54,6 +54,7 @@ func (d *Driver) StartWithCancel() (*StartedService, error) {
 	if d.CaptureDriverLogs {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
 	} else if d.LogOutputDir != "" && (d.SaveAllLogs || d.Log) {
 		filename := filepath.Join(d.LogOutputDir, d.LogName)
 		f, err := os.Create(filename)


### PR DESCRIPTION
We have a setup of selenoid (disable-docker, custom build) <> WinAppDriver running for past couple of years. There were small changes needed to make it work, one of them is capturing Stdin of the WinAppDriver process. Not sure if CaptureDriverLogs is the right place for it, but I did not find any place that looked better. Looking forward to the comments and happy to dicuss/adjust the PR as needed.